### PR TITLE
Testing bugfix

### DIFF
--- a/tests/e2e-tests/demo.test.ts
+++ b/tests/e2e-tests/demo.test.ts
@@ -1,11 +1,26 @@
 import puppeteer from "puppeteer"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
-import { resetTestDatabase, reseedTestDatabase } from "../test-utils"
+import {
+  resetTestDatabase,
+  reseedTestDatabase,
+  retryOperation,
+  waitForServer,
+} from "../test-utils"
+import { spawn } from "child_process"
 
 let browser
 let page
 
+let serverProcess
+
 beforeAll(async () => {
+  await resetTestDatabase()
+
+  // Start your dev server process (adjust command as needed)
+  serverProcess = spawn("npm", ["run", "dev"], { stdio: "inherit" })
+
+  // Wait for server to be ready
+  await waitForServer("http://localhost:5173/", 30000)
   await resetTestDatabase()
   browser = await puppeteer.launch()
   page = await browser.newPage()
@@ -17,30 +32,32 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await browser.close()
+  if (serverProcess) {
+    serverProcess.kill()
+  }
 })
 
 describe("Calendar Button", async () => {
   it("exists in Nav", async () => {
-
-    await page.goto("http://localhost:5173/")
-
+    const url = "http://localhost:5173/"
+    await retryOperation(() => page.goto(url), 10)
     await page.setViewport({ width: 1080, height: 1024 })
 
     const calendarButtonSelector = "button"
     const calendarButtonRes = await page.waitForSelector(calendarButtonSelector)
-    const calendarTitle = await calendarButtonRes?.evaluate((el) => el.textContent)
+    const calendarTitle = await calendarButtonRes?.evaluate(
+      (el) => el.textContent
+    )
     expect(calendarTitle).toBe("Calendar")
-
   })
 
   it("navigates to Calendar Tab", async () => {
-
     await page.goto("http://localhost:5173/")
 
     await page.setViewport({ width: 1080, height: 1024 })
 
     const headerSelector = "H1"
-    const headerRes = await page.waitForSelector(headerSelector)   
+    const headerRes = await page.waitForSelector(headerSelector)
     const fullTitle = await headerRes?.evaluate((el) => el.textContent)
     expect(fullTitle).toBe("Acupuncture Clinic Management")
 
@@ -50,7 +67,9 @@ describe("Calendar Button", async () => {
 
     const calendarTitleSelector = ".MuiCardHeader-root"
     const calendarTitleRes = await page.waitForSelector(calendarTitleSelector)
-    const calendarTitle = await calendarTitleRes?.evaluate((el) => el.textContent)
+    const calendarTitle = await calendarTitleRes?.evaluate(
+      (el) => el.textContent
+    )
     expect(calendarTitle).toBe("Appointments")
   })
-})
+}, 50000)

--- a/tests/e2e-tests/demo.test.ts
+++ b/tests/e2e-tests/demo.test.ts
@@ -8,18 +8,13 @@ import {
 } from "../test-utils"
 import { spawn } from "child_process"
 
+let serverProcess
 let browser
 let page
 
-let serverProcess
-
 beforeAll(async () => {
   await resetTestDatabase()
-
-  // Start your dev server process (adjust command as needed)
   serverProcess = spawn("npm", ["run", "dev"], { stdio: "inherit" })
-
-  // Wait for server to be ready
   await waitForServer("http://localhost:5173/", 30000)
   await resetTestDatabase()
   browser = await puppeteer.launch()

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -2,10 +2,38 @@ import { dropAllTables } from "../server/database/scripts/dropAllTables"
 import { migrate } from "../server/database/scripts/migrate"
 import { seed } from "../server/database/scripts/seed"
 
-export async function resetTestDatabase () {
+export async function resetTestDatabase() {
   await dropAllTables()
   await migrate()
   await seed()
 }
 
 export const reseedTestDatabase = seed
+
+export async function waitForServer(url, timeout = 30000) {
+  const start = Date.now()
+  while (Date.now() - start < timeout) {
+    try {
+      await fetch(url)
+      console.log("Server is up!")
+      return
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (err) {
+      await new Promise((res) => setTimeout(res, 500))
+    }
+  }
+  throw new Error("Server did not start in time")
+}
+
+export async function retryOperation(operation, retries, delay = 1000) {
+      for (let i = 0; i < retries; i++) {
+        try {
+          return await operation();
+        } catch (error) {
+          if (i === retries - 1) {
+            throw error; // Re-throw the error if all retries fail
+          }
+          await new Promise(res => setTimeout(res, delay)); // Wait before retrying
+        }
+      }
+    }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/cypress/**",
+      "**/.{idea,git,cache,output,temp}/**",
+      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
+    ],
+    fileParallelism: false,
+  },
+})


### PR DESCRIPTION
Fixed 2 testing bugs:

Parallelism: The test files were running in parallel, which is a feature of Vitest to improve efficiency, but it led to a race condition with resetting the test DB. Fixed by setting parallelism to false in `vitest.config.ts`

Puppeteer tests timeout: If the dev server was not already running in the background, the Puppeteer tests would time out. Fixed by invoking the dev server explicitly in the `beforeAll` and killing it in the `afterAll`